### PR TITLE
Fix regression upload-pages-artifact@v1.0.9, set required permissions manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,7 +268,7 @@ jobs:
           echo "</body></html>"                                              >> target-ALL/site/index.html
       - if: always()
         name: Publish test report files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: "test-report-ALL"
           path: |
@@ -280,6 +280,11 @@ jobs:
             **/reports/*.log
             
       # Deploy to GitHub Pages
+      # Some files (e.g. junit reports) have 600 permissions.
+      # As of upload-pages-artifact@v1.0.9, permissions must be set explicitly
+      # to 0755 (as indicated in warnings produced by v1.0.8)
+      - name: Fix permissions to actions/upload-pages-artifact@v1.0.9
+        run: sudo chmod -c -R 0755 target-ALL/site
       - name: Upload artifact
         if: always()
         uses: actions/upload-pages-artifact@v1.0.9


### PR DESCRIPTION
v1.0.9 does not set the required permissions to upload and deploy artifacts to github pages
- Some files (e.g. junit reports) have 600 permissions.
- As of upload-pages-artifact@v1.0.9, permissions must be set explicitly
- Set permissions to 0755 (as indicated in warnings produced by v1.0.8)