### PR TITLE
Combined dependency updates (2023-08-12)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,7 +293,7 @@ jobs:
       - name: Deploy to GitHub Pages
         if: always()
         id: deployment
-        uses: actions/deploy-pages@v2.0.3
+        uses: actions/deploy-pages@v2.0.4
         
   sonarqube:
     needs: [test-java]

--- a/net/TdRules/TdRules.csproj
+++ b/net/TdRules/TdRules.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="PortableCs" Version="2.2.0" />
     
-    <PackageReference Include="NLog" Version="5.2.2" />
+    <PackageReference Include="NLog" Version="5.2.3" />
 
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
 

--- a/net/TdRulesTest/TdRulesTest.csproj
+++ b/net/TdRulesTest/TdRulesTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>    
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     
     <PackageReference Include="NUnit" Version="3.13.3" />
     

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>
-				<version>21.10.0.0</version>
+				<version>21.11.0.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.3.8</version>
+				<version>1.3.11</version>
 				<scope>test</scope>
 			</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 			<dependency>
 				<groupId>commons-dbutils</groupId>
 				<artifactId>commons-dbutils</artifactId>
-				<version>1.7</version>
+				<version>1.8.0</version>
 				<scope>test</scope>
 			</dependency>
 			


### PR DESCRIPTION
Includes these updates:
- [Bump actions/deploy-pages from 2.0.3 to 2.0.4](https://github.com/giis-uniovi/tdrules/pull/33)
- [Bump ch.qos.logback:logback-classic from 1.3.8 to 1.3.11](https://github.com/giis-uniovi/tdrules/pull/32)
- [Bump com.oracle.database.jdbc:ojdbc8 from 21.10.0.0 to 21.11.0.0](https://github.com/giis-uniovi/tdrules/pull/31)
- [Bump commons-dbutils:commons-dbutils from 1.7 to 1.8.0](https://github.com/giis-uniovi/tdrules/pull/30)
- [Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 in /net](https://github.com/giis-uniovi/tdrules/pull/28)
- [Bump NLog from 5.2.2 to 5.2.3 in /net](https://github.com/giis-uniovi/tdrules/pull/29)