### PR TITLE
Combined dependency updates (2023-08-19)

### DIFF
--- a/net/TdRules/TdRules.csproj
+++ b/net/TdRules/TdRules.csproj
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PortableCs" Version="2.2.0" />
+    <PackageReference Include="PortableCs" Version="2.2.2" />
     
     <PackageReference Include="NLog" Version="5.2.3" />
 

--- a/net/TdRulesTest/TdRulesTest.csproj
+++ b/net/TdRulesTest/TdRulesTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     
     <PackageReference Include="NUnit" Version="3.13.3" />
     


### PR DESCRIPTION
Includes these updates:
- [Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 in /net](https://github.com/giis-uniovi/tdrules/pull/38)
- [Bump PortableCs from 2.2.0 to 2.2.2 in /net](https://github.com/giis-uniovi/tdrules/pull/39)